### PR TITLE
Shared tasks

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -25,11 +25,11 @@ function matchTasks(pattern) {
     }
   }
 
-  return matchingTasks
+  return matchingTasks;
 }
 
 function getDirTasks(dir) {
-  return Object.keys(require(path.join(dir, 'package.json')).scripts)
+  return Object.keys(require(path.join(dir, 'package.json')).scripts);
 }
 
 module.exports = { matchTasks }

--- a/lib/match.js
+++ b/lib/match.js
@@ -2,10 +2,34 @@ const path = require('path');
 const pm = require('picomatch');
 
 function matchTasks(pattern) {
-  const packageJsonTasks = Object.keys(require(path.join(process.cwd(), 'package.json')).scripts);
-  const isMatch = pm(pattern);
+  const cwd = process.cwd();
+  const projectCwd = process.env.PROJECT_CWD;
 
-  return packageJsonTasks.filter(task => isMatch(task));
+  const isMatch = pm(pattern);
+  const matchingTasks = [];
+
+  for (let task of getDirTasks(cwd)) {
+    if (isMatch(task)) {
+      matchingTasks.push(task);
+    }
+  }
+
+  // Yarn allows tasks with a colon (:) to be be shared across workspaces
+  // https://yarnpkg.com/getting-started/qa#how-to-share-scripts-between-workspaces
+  // If the current dir is NOT the project root, search the root for the task too
+  if (projectCwd && projectCwd !== cwd) {
+    for (let task of getDirTasks(projectCwd)) {
+      if (task.indexOf(':') !== -1 && isMatch(task)) {
+        matchingTasks.push(task);
+      }
+    }
+  }
+
+  return matchingTasks
+}
+
+function getDirTasks(dir) {
+  return Object.keys(require(path.join(dir, 'package.json')).scripts)
 }
 
 module.exports = { matchTasks }


### PR DESCRIPTION
Yarn supports [sharing tasks across workspaces](https://yarnpkg.com/getting-started/qa#how-to-share-scripts-between-workspaces) if they have a colon. Prior to this change, if the current directory was a child workspace and `yall` was run invoking a shared task in the parent, yall would error out. I've extended the code to check the root workspace for tasks too.

PS- I love the succinctness yall-scripts offers. It has really made my package.json much more readable!