### PR TITLE
new workspaces options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ yall [options] [tasks] [forward-options]
 Options:
   -s, --serial, --sequential, --sequence  // run tasks in sequence
   -p, --parallel                          // run tasks in parallel
+  -w, --workspaces                        // run tasks in all child workspaces
+  -q, --quiet                             // don't print verbose workspace information
   -v, --version                           // print version
   -h, --help                              // print help
 ```
@@ -36,6 +38,18 @@ Run tasks in parallel:
 ```js
 $ yall -p clean lint test build
 $ yall --parallel clean lint test build
+```
+
+Run tasks in all child workspaces:
+```js
+$ yall -w clean lint test build
+$ yall --workspaces clean lint test build
+```
+
+Combine multiple options:
+```js
+$ yall -pwq clean lint test build
+$ yall --parallel --workspaces --quiet clean lint test build
 ```
 
 Run tasks using matching patterns:

--- a/lib/help.js
+++ b/lib/help.js
@@ -10,6 +10,8 @@ module.exports = function help() {
   Options:
     -s, --serial, --sequential, --sequence    run tasks in sequence
     -p, --parallel                            run tasks in parallel
+    -w, --workspaces                          run tasks in all child workspaces
+    -q, --quiet                               don't print verbose workspace information
     -v, --version                             print version
     -h, --help                                print help
 
@@ -24,6 +26,14 @@ module.exports = function help() {
     Run tasks in parallel:
       $ yall -p clean lint test build
       $ yall --parallel clean lint test build
+
+    Run tasks in all child workspaces:
+      $ yall -w clean lint test build
+      $ yall --workspaces clean lint test build
+
+    Combine multiple options:
+      $ yall -pwq clean lint test build
+      $ yall --parallel --workspaces --quiet clean lint test build
 
     Run tasks using matching patterns:
       $ yall lint:*                           run lint:js, lint:css, lint:js:bin, lint:js:lib

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,7 +9,7 @@ function parseArgs(args) {
 
   args.forEach((arg) => {
     if (!pointer && arg.match(optionRe)) {
-      options.push(arg);
+      options.push(...expandCharOptions(arg));
     } else {
       pointer = !pointer ? 1 : pointer;
       if (pointer === 1 && !arg.match(optionRe)) {
@@ -24,10 +24,12 @@ function parseArgs(args) {
   return { options, tasks, forwardOptions };
 }
 
-function parseOptions (options) {
+function parseOptions(options) {
   const partialConfigs = {
     parallel:   { parallel: true },
     serial:     { parallel: false },
+    workspaces: { workspaces: true },
+    quiet:      { quiet: true },
   };
 
   const defaultConfig = { ...partialConfigs.serial };
@@ -39,6 +41,10 @@ function parseOptions (options) {
     '--serial':       partialConfigs.serial,
     '--sequence':     partialConfigs.serial,
     '--sequential':   partialConfigs.serial,
+    '-w':             partialConfigs.workspaces,
+    '--workspaces':   partialConfigs.workspaces,
+    '-q':             partialConfigs.quiet,
+    '--quiet':        partialConfigs.quiet,
   };
   const expectedOptions = Object.keys(optionToPartialConfigMap);
 
@@ -51,6 +57,20 @@ function parseOptions (options) {
     },
     { ...defaultConfig },
   );
+}
+
+// converts a string like '-pwq' to ['-p', '-w', '-q']
+function expandCharOptions(s) {
+  const match = s.match(/^-([A-z]+)$/) // only matches single-dash
+  if (match) {
+    const letters = match[1];
+    const options = [];
+    for (let i = 0; i < letters.length; i++) {
+      options.push('-' + letters.charAt(i));
+    }
+    return options;
+  }
+  return [s];
 }
 
 module.exports = { parseArgs, parseOptions }

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,8 +1,13 @@
+const path = require('path')
 const crossSpawn = require('cross-spawn');
 
 module.exports = function spawn(config, tasks, forwardOptions) {
+  const preArgs = config.workspaces
+    ? buildWorkspacePreArgs(config.parallel, config.quiet)
+    : [];
+
   tasks.forEach(task => {
-    const args = ['run', task, ...forwardOptions];
+    const args = [...preArgs, 'run', task, ...forwardOptions];
     const options = { stdio: 'inherit' };
 
     if (config.parallel) {
@@ -20,4 +25,28 @@ module.exports = function spawn(config, tasks, forwardOptions) {
       }
     }
   })
+}
+
+function buildWorkspacePreArgs(parallel, quiet) {
+  const rootPkgDir = process.env.PROJECT_CWD;
+  const preArgs = ['workspaces', 'foreach'];
+
+  if (parallel) {
+    preArgs.push('--parallel', '--interlaced');
+  }
+
+  if (!quiet) {
+    preArgs.push('--verbose');
+  }
+
+  // Yarn's foreach stupidly includes the root package. Explicitly exclude it.
+  if (rootPkgDir) {
+    const rootPkgName = require(path.join(rootPkgDir, 'package.json')).name;
+    if (!rootPkgName) {
+      throw new Error('Workspaces root must have package name');
+    }
+    preArgs.push('--exclude', rootPkgName);
+  }
+
+  return preArgs;
 }


### PR DESCRIPTION
A added a super-useful `--workspaces` option that runs all commands in all child workspaces. Respects `--parallel`. Also added a new option for NOT showing the workspace prefix before each line of output (`--quiet`).

I also added the ability to combine flags (`-wpq` for example).

All this takes a statement that would normally like like this:

```sh
yarn workspaces foreach -p --exclude workspace-root run pkg:clean
```

and turns it into:

```sh
yall -pwq pkg:clean
```